### PR TITLE
Fix: Ensure bids graph displays consistently

### DIFF
--- a/src/services/dataframes.py
+++ b/src/services/dataframes.py
@@ -110,15 +110,20 @@ def get_bids_dataframe(
 
     bids_df = pd.DataFrame([b.model_dump() for b in bids_list])
 
-    # Map bidder_id to bidder_name
-    if not bids_df.empty and bidders_list: # Ensure bidders_list is not empty
-        bidder_map = {b.id: b.name for b in bidders_list} # Renamed variable
-        # Ensure 'bidder_id' column exists from model_dump() before trying to map it
-        if "bidder_id" in bids_df.columns:
-            bids_df["bidder_name"] = bids_df["bidder_id"].map(bidder_map) 
-            bids_df["bidder_name"].fillna("N/D", inplace=True) # Handle None/NaN bidder_id cases
+    # Ensure 'bidder_name' column is always present
+    if not bids_df.empty:
+        if bidders_list:  # Check if bidders_list is provided and not empty
+            bidder_map = {b.id: b.name for b in bidders_list}
+            if "bidder_id" in bids_df.columns:
+                bids_df["bidder_name"] = bids_df["bidder_id"].map(bidder_map)
+                bids_df["bidder_name"].fillna("N/D", inplace=True)
+            else:
+                # If bidder_id column does not exist, fill bidder_name with "N/D"
+                bids_df["bidder_name"] = "N/D"
         else:
-            bids_df["bidder_name"] = "N/D" # If bidder_id column itself is missing, fill all with N/D
+            # If bidders_list is empty or not provided, fill bidder_name with "N/D"
+            bids_df["bidder_name"] = "N/D"
+    # If bids_df is empty, the initial check for bids_list already handles returning a DataFrame with bidder_name
 
     if "created_at" in bids_df.columns:
         bids_df["created_at"] = pd.to_datetime(bids_df["created_at"]).dt.strftime(


### PR DESCRIPTION
The bids graph was not appearing if bidder information was partially unavailable.

This commit addresses the issue by:
1. Modifying `get_bids_dataframe` in `src/services/dataframes.py` to always create the `bidder_name` column. If bidder details are not found for a bid, `bidder_name` defaults to "N/D". This ensures the DataFrame passed to the plotting function always has the required columns.
2. Adding comprehensive unit tests for `get_bids_dataframe` in `src/tests/services/test_dataframes.py`. These tests cover scenarios with empty bid lists, empty bidder lists, and bids with matched, unmatched, or None `bidder_id`s, verifying the robustness of the `bidder_name` population.

With these changes, the bids graph should now render as long as there are bids to display, using "N/D" for bidders that cannot be identified, instead of failing to render the graph entirely.