### PR TITLE
Fix: Initialize edited_quotes_df to prevent UnboundLocalError

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -453,6 +453,7 @@ def show_main_view():
                         items_list=all_items_list
                     )
 
+                    edited_quotes_df = pd.DataFrame()
                     table_cols_display = st.columns(2)
                     with table_cols_display[0]:
                         st.markdown("##### Orçamentos do Item")


### PR DESCRIPTION
Initialize `edited_quotes_df` to an empty pandas DataFrame at the beginning of its scope in the `show_main_view` function.

This prevents an UnboundLocalError that occurred when `original_quotes_df` was empty, as `edited_quotes_df` would not have been defined before being accessed in the graph generation section.